### PR TITLE
Fix append a redundant space in auto select mode.

### DIFF
--- a/engine/table.py
+++ b/engine/table.py
@@ -2552,9 +2552,7 @@ class tabengine (IBus.Engine):
                 return True
 
         if key.val in self._commit_keys:
-            if self.commit_everything_unless_invalid():
-                if self._editor._auto_select:
-                    self.commit_string(u' ')
+            self.commit_everything_unless_invalid()
             return True
 
         if key.val in self._page_down_keys and self._editor._candidates:


### PR DESCRIPTION
Before this, in auto select mode, When I want to input chinese character "我" by zhengma, these keys "m space" will be typed. but the result is "我 space". This patch will remove the redundant space in result.