### PR TITLE
Stop rewriting the phrases cache every 30s while idle

### DIFF
--- a/engine/factory.py
+++ b/engine/factory.py
@@ -126,6 +126,7 @@ class EngineFactory(IBus.Factory):
         ## we need to sync the temp userdb in memory to the user_db on disk
         for key, database in self.dbdict.items():
             LOGGER.info('Syncing %s %s', key, database)
+            database.save_phrases_cache()
             database.sync_usrdb()
         ##print "Have synced user db\n"
         super().destroy()

--- a/engine/table.py
+++ b/engine/table.py
@@ -1981,6 +1981,7 @@ class TabEngine(IBus.EngineSimple):
             self.sync_timeout_id = 0
         self.reset()
         self.do_focus_out()
+        self.database.save_phrases_cache()
         if self._save_user_count > 0:
             self.database.sync_usrdb()
             self._save_user_count = 0
@@ -3203,7 +3204,7 @@ class TabEngine(IBus.EngineSimple):
 
     def _sync_user_db(self) -> bool:
         """Save user db to disk"""
-        if self._save_user_count >= 0:
+        if self._save_user_count > 0:
             now = time.time()
             time_delta = now - self._save_user_start
             if (self._save_user_count > self._save_user_count_max or

--- a/engine/tabsqlitedb.py
+++ b/engine/tabsqlitedb.py
@@ -159,6 +159,7 @@ class TabSqliteDb:
         self.old_phrases: List[Tuple[str, str, int, int]] = []
         self.filename = filename
         self._user_db = user_db
+        self._phrases_cache_dirty = False
         self.reset_phrases_cache()
 
         if create_database or os.path.isfile(self.filename):
@@ -471,7 +472,6 @@ class TabSqliteDb:
         '''
         Trigger a checkpoint operation.
         '''
-        self.save_phrases_cache()
         if self._user_db is None:
             return
         self.db.commit()
@@ -483,6 +483,8 @@ class TabSqliteDb:
         '''
         if DEBUG_LEVEL > 1:
             LOGGER.debug('reset_phrases_cache()')
+        if getattr(self, '_phrases_cache', None):
+            self._phrases_cache_dirty = True
         self._phrases_cache: Dict[str, Union[str, Iterable[Tuple[str, str, int, int]]]]= {}
 
     def invalidate_phrases_cache(self, tabkeys: str = '') -> None:
@@ -497,6 +499,7 @@ class TabSqliteDb:
         for i in range(1, self._mlen + 1):
             if self._phrases_cache.get(tabkeys[0:i]):
                 self._phrases_cache.pop(tabkeys[0:i])
+                self._phrases_cache_dirty = True
 
     def load_phrases_cache(self) -> None:
         '''
@@ -522,11 +525,19 @@ class TabSqliteDb:
             LOGGER.exception(
                 'Unknown error reading %s: %s: %s',
                 self.cache_path, error.__class__.__name__, error)
+        # Whatever happened above, _phrases_cache now matches what is
+        # (or should be, if unreadable/absent) on disk, so there is
+        # nothing new to write out yet.
+        self._phrases_cache_dirty = False
 
     def save_phrases_cache(self) -> None:
         '''
         Save phrases cache from disk
         '''
+        if not self._phrases_cache_dirty:
+            if DEBUG_LEVEL > 1:
+                LOGGER.debug('save_phrases_cache(): cache unchanged, skipping write')
+            return
         if DEBUG_LEVEL > 1:
             LOGGER.debug('save_phrases_cache()')
         try:
@@ -537,6 +548,7 @@ class TabSqliteDb:
             with open(_cache_path, 'w', encoding='utf-8') as f:
                 json.dump(self._phrases_cache, f)
             os.replace(_cache_path, self.cache_path)
+            self._phrases_cache_dirty = False
         except Exception as error: # pylint: disable=broad-except
             LOGGER.exception(
                 'Unexpected error in save_phrases_cache(): %s: %s',
@@ -1169,6 +1181,7 @@ class TabSqliteDb:
         if DEBUG_LEVEL > 1:
             LOGGER.debug('best=%s', repr(best))
         self._phrases_cache[tabkeys] = best
+        self._phrases_cache_dirty = True
         return best
 
     def select_chinese_characters_by_pinyin(

--- a/tests/mock_engine.py
+++ b/tests/mock_engine.py
@@ -70,6 +70,9 @@ class MockEngine:
     def hide_preedit_text(self) -> None:
         pass
 
+    def destroy(self) -> None:
+        pass
+
     def commit_text(self, text: IBus.Text) -> None:
         self.mock_committed_text = (
             self.mock_committed_text[

--- a/tests/test_it.py
+++ b/tests/test_it.py
@@ -27,6 +27,7 @@ import sys
 import os
 import logging
 import time
+import tempfile
 import unittest
 import importlib
 from unittest import mock
@@ -1794,6 +1795,111 @@ class LatexTestCase(unittest.TestCase):
         self.assertEqual(ENGINE._lookup_table.get_cursor_pos(), 15)
         ENGINE._do_process_key_event(IBus.KEY_space, 0, 0)
         self.assertEqual(ENGINE.mock_committed_text, 'β⊞≬')
+
+class PhrasesCacheSyncTestCase(unittest.TestCase):
+    '''
+    Regression tests for the phrases-cache idle-rewrite bug:
+    _sync_user_db() used to trigger a full save_phrases_cache() every
+    30s even when nothing was typed (guard was “>= 0” instead of
+    “> 0”), and sync_usrdb() used to drag save_phrases_cache() along
+    on every 16th committed phrase while typing.
+    '''
+    def setUp(self) -> None:
+        engine_name = 'cangjie5'
+        if not set_up(engine_name):
+            self.skipTest(f'Could not setup “{engine_name}”, skipping test.')
+
+    def tearDown(self) -> None:
+        tear_down()
+
+    def test_idle_never_syncs(self) -> None:
+        '''5 minutes idle, zero keystrokes: sync_usrdb() must never fire.'''
+        assert ENGINE is not None
+        ENGINE._save_user_count = 0
+        ENGINE._save_user_start = 0.0
+        with mock.patch.object(ENGINE.database, 'sync_usrdb') as mock_sync:
+            with mock.patch.object(table.time, 'time') as mock_time:
+                for second in range(1, 301):
+                    mock_time.return_value = float(second)
+                    ENGINE._sync_user_db()
+        self.assertEqual(mock_sync.call_count, 0)
+
+    def test_typing_syncs_once_after_max_count(self) -> None:
+        '''
+        Committing more phrases than _save_user_count_max must still
+        trigger exactly one sync_usrdb() call (that part of the timer
+        is intentional and unchanged).
+        '''
+        assert ENGINE is not None
+        ENGINE._save_user_count = 0
+        ENGINE._save_user_start = 0.0
+        with mock.patch.object(ENGINE.database, 'sync_usrdb') as mock_sync:
+            with mock.patch.object(table.time, 'time') as mock_time:
+                fake_now = 0.0
+                for _unused in range(ENGINE._save_user_count_max + 1):
+                    fake_now += 0.5
+                    mock_time.return_value = fake_now
+                    if ENGINE._save_user_count <= 0:
+                        ENGINE._save_user_start = fake_now
+                    ENGINE._save_user_count += 1
+                    ENGINE._sync_user_db()
+        self.assertEqual(mock_sync.call_count, 1)
+
+    def test_sync_usrdb_no_longer_touches_cache(self) -> None:
+        '''sync_usrdb() must not call save_phrases_cache() anymore.'''
+        assert TABSQLITEDB is not None
+        with mock.patch.object(
+                TABSQLITEDB, 'save_phrases_cache') as mock_save:
+            TABSQLITEDB.sync_usrdb()
+        mock_save.assert_not_called()
+
+    def test_do_destroy_saves_cache_unconditionally(self) -> None:
+        '''
+        do_destroy() must always flush the phrases cache to disk, even
+        if nothing was typed (_save_user_count == 0), since
+        sync_usrdb() no longer does that implicitly.
+        '''
+        assert ENGINE is not None
+        ENGINE._save_user_count = 0
+        with mock.patch.object(
+                ENGINE.database, 'save_phrases_cache') as mock_save, \
+             mock.patch.object(ENGINE.database, 'sync_usrdb') as mock_sync:
+            ENGINE.do_destroy()
+        mock_save.assert_called_once()
+        mock_sync.assert_not_called()
+
+    def test_save_phrases_cache_skips_when_not_dirty(self) -> None:
+        '''
+        save_phrases_cache() must not touch disk at all if nothing was
+        added to or removed from the cache since the last save/load
+        (do_destroy() now calls it unconditionally, so this is what
+        keeps closing an engine that never did any lookups cheap).
+        '''
+        assert TABSQLITEDB is not None
+        TABSQLITEDB._phrases_cache_dirty = False
+        with mock.patch('builtins.open') as mock_open:
+            TABSQLITEDB.save_phrases_cache()
+        mock_open.assert_not_called()
+
+    def test_save_phrases_cache_writes_when_dirty(self) -> None:
+        '''
+        A real lookup must mark the cache dirty, and
+        save_phrases_cache() must then actually write it and clear
+        the flag again.
+        '''
+        assert TABSQLITEDB is not None
+        TABSQLITEDB._phrases_cache_dirty = False
+        TABSQLITEDB.select_words(tabkeys='a', chinese_mode=4)
+        self.assertTrue(TABSQLITEDB._phrases_cache_dirty)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            original_cache_path = TABSQLITEDB.cache_path
+            TABSQLITEDB.cache_path = os.path.join(tmp_dir, 'test.cache')
+            try:
+                TABSQLITEDB.save_phrases_cache()
+                self.assertTrue(os.path.isfile(TABSQLITEDB.cache_path))
+            finally:
+                TABSQLITEDB.cache_path = original_cache_path
+        self.assertFalse(TABSQLITEDB._phrases_cache_dirty)
 
 if __name__ == '__main__':
     LOG_HANDLER = logging.StreamHandler(stream=sys.stderr)


### PR DESCRIPTION
Fixes [#223](https://github.com/mike-fabian/ibus-table/issues/233)

## Summary

`TabEngine._sync_user_db()` guards its periodic sync with `self._save_user_count >= 0`,
which is always true (the counter is `0` when nothing has been typed), so the phrases
cache gets a full `json.dump()` rewrite every 30s for the whole session, even with zero
keystrokes. The same counter is guarded correctly (`> 0`) in `do_destroy()`, so this
looks like a latent regression: the `>= 0` guard is from 2012 when the timer only did a
cheap `commit()` + `wal_checkpoint`, and `save_phrases_cache()` was prepended to
`sync_usrdb()` in 2017 without updating the guard.

It also means every ~17th committed phrase drags a full cache rewrite along with the
(cheap) user-db sync — a stall on the GLib main loop in the middle of typing.

## Fix

- `table.py`: `>= 0` → `> 0` in `_sync_user_db()`, so the periodic sync only runs when
  something was actually typed.
- `tabsqlitedb.py`: decouple `save_phrases_cache()` from `sync_usrdb()` entirely, since
  `sync_usrdb()` also runs on the typing-driven 16-commit branch, which should stay
  cheap.

Removing `save_phrases_cache()` from `sync_usrdb()` also removes it from the two places
that relied on that cascade to persist the cache at all
(`TabEngine.do_destroy()` and `EngineFactory.do_destroy()`), so both now call it
explicitly instead:

- `EngineFactory.do_destroy()` is the final catch-all — it iterates every loaded
  `TabSqliteDb` once, at full `ibus-daemon` shutdown. Without this call the on-disk
  cache would never update again after the first session.
- `TabEngine.do_destroy()` fires whenever an individual engine *instance* is destroyed
  (e.g. switching input methods, closing an input context) — far more often in practice
  than the whole daemon restarting. Skipping this would leave a much bigger window
  where accumulated cache updates only exist in memory and are lost to a crash or
  forced kill.

Together they keep the cache's on-disk benefit for next launch without reintroducing a
write on any per-keystroke or timer-driven path. The remaining tradeoff — a very
long-running session with no engine ever destroyed and no clean daemon shutdown could
still lose accumulated cache on a hard crash — is the same one already accepted in the
original report, since the cache is a derived, rebuildable performance optimization,
not authoritative data.

Note these two calls are unconditional (not gated on `_save_user_count`, unlike the
original `do_destroy()`), since the cache is populated by *lookups*, not commits — a
session that only ever browses candidates without committing anything would never bump
that counter, so gating on it would silently drop real cache updates. (This was already
true of the pre-existing guard; it just never mattered while `sync_usrdb()` was the only
caller of `save_phrases_cache()`.)

Making both shutdown paths call `save_phrases_cache()` on every destroy regardless of
whether anything changed reintroduces a shrunk-down version of the exact "no check for
whether the cache changed" problem this PR exists to remove — just once per engine
shutdown instead of every 30s. So `tabsqlitedb.py` also gets a `_phrases_cache_dirty`
flag: set on every real mutation (a lookup caching new candidates,
`invalidate_phrases_cache()` removing entries, `reset_phrases_cache()` clearing a
non-empty cache — e.g. "delete all learned data"), cleared after a successful load or
save. `save_phrases_cache()` now skips the write entirely when nothing is dirty, so
opening and closing an engine that never did a single lookup writes nothing at all.

## Testing

Confirmed live on Ubuntu 24.04 / GNOME 46: polling the cache file's mtime every 5s for
100 idle seconds with a table engine focused showed 9 rewrites with zero keystrokes
before this change; 0 after.

Also verified directly against the patched code (binding the real methods rather than a
mirrored copy): the typing-driven sync still fires exactly once per 17 commits, and
`sync_usrdb()` no longer touches the cache file while `save_phrases_cache()` still works
when called explicitly.

Added `tests/test_it.py::PhrasesCacheSyncTestCase` (6 tests) against the real
`TabEngine`/`TabSqliteDb` classes used by the rest of the suite — idle never syncs,
typing still syncs once per 16 commits, `sync_usrdb()` no longer touches the cache,
`do_destroy()` always saves it, and `save_phrases_cache()` skips the write when the
cache isn't dirty but performs it when it is. Also added a one-line `MockEngine.destroy()`
no-op to `tests/mock_engine.py`, needed because `do_destroy()` calls `super().destroy()`
and no prior test exercised that path.

Full suite (`tests/test_it.py`) passes: 35 passed, 14 skipped (pre-existing, missing
table dictionaries unrelated to this change), 0 failures. Confirmed the real on-disk
cache files for tables not involved in the test run are untouched by it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved phrase-cache persistence during database shutdown and synchronization.
  - Avoided unnecessary database synchronization when no user changes are pending.
  - Ensured cache updates are written only when changes have occurred.
  - Improved cleanup and temporary-file handling during shutdown.

- **Tests**
  - Added coverage for cache synchronization, dirty-cache handling, shutdown cleanup, and idle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->